### PR TITLE
API Endpoint URL and image size attributes

### DIFF
--- a/app/pages/Home.vue
+++ b/app/pages/Home.vue
@@ -41,7 +41,7 @@
               source(media="(max-width: 843px)" srcset="../assets/fabricatedSeal_562w.jpg")
               source(media="(min-width: 844px)" srcset="../assets/fabricatedSeal_1124w.webp")
               source(media="(min-width: 844px)" srcset="../assets/fabricatedSeal_1124w.jpg")
-              img(src="../assets/fabricatedSeal_1124w.jpg" alt="Selbstgemachter Siegelstempel" width="1124" height="750")
+              img(src="../assets/fabricatedSeal_1124w.jpg" alt="Selbstgemachter Siegelstempel" width="1124" height="750" loading="lazy" decoding="async")
         .info-section
           .picture
             picture
@@ -51,7 +51,7 @@
               source(media="(max-width: 768px)" srcset="../assets/resindruckerErgebnis_512w.jpg")
               source(media="(min-width: 769px)" srcset="../assets/resindruckerErgebnis_1024w.webp")
               source(media="(min-width: 769px)" srcset="../assets/resindruckerErgebnis_1024w.jpg")
-              img(src="../assets/resindruckerErgebnis_1024w.jpg" alt="Resindrucker" width="1024" height="768")
+              img(src="../assets/resindruckerErgebnis_1024w.jpg" alt="Resindrucker" width="1024" height="768" loading="lazy" decoding="async")
           .text
             h2 How to Fabricate
             p Wie funktioniert nun die Herstellung des Siegels genau? Womit lässt sich ein Siegelstempel herstellen? Beim Durchstöbern der Siegel kann eines ausgewählt werden, welches dann als 3D-Modell angezeigt wird. Dort lässt sich sowohl eine 3D-Vorlage für die und im #[router-link(to="/guide") Herstellung mit dem 3D-Drucker] als auch eine Vektordatei für die Herstellung mit dem Lasercutter runterladen. Die besten Druckergebnisse erzielt ein Resindrucker mittels Kunstharz. Frag am besten im FabLab oder Makerspace in deiner Nähe nach, ob dort ein solcher Drucker vorhanden ist. Alternativ kannst du auch einen herkömmlichen 3D-Drucker zu Hause nutzen, der bspw mit PLA-Filament arbeitet. Hier könnten die Ergebnisse verbessert werden, indem das 3D-Modell ein leicht tieferes Relief erhält. Die Vorlage für den Lasercutter kannst du auch nutzen, um einen Siegelstempel aus Moosgummi mit einem Hobbyplotter herzustellen.
@@ -67,7 +67,7 @@
               source(media="(max-width: 856px)" srcset="../assets/siegelsammlung_grun_571w.jpg")
               source(media="(min-width: 857px)" srcset="../assets/siegelsammlung_grun_1142w.webp")
               source(media="(min-width: 857px)" srcset="../assets/siegelsammlung_grun_1142w.jpg")
-              img(src="../assets/siegelsammlung_grun_1142w.jpg" alt="Siegelsammlung Grun" width="1142" height="922")
+              img(src="../assets/siegelsammlung_grun_1142w.jpg" alt="Siegelsammlung Grun" width="1142" height="922" loading="lazy" decoding="async")
         .info-section
           .picture
             picture
@@ -77,12 +77,12 @@
               source(media="(max-width: 960px)" srcset="../assets/pipeline_640w.gif")
               source(media="(min-width: 961px)" srcset="../assets/pipeline_1280w.webp")
               source(media="(min-width: 961px)" srcset="../assets/pipeline_1280w.gif")
-              img(src="../assets/pipeline_1280w.gif" alt="Pipeline" width="1280" height="696")
+              img(src="../assets/pipeline_1280w.gif" alt="Pipeline" width="1280" height="696" loading="lazy" decoding="async")
           .text
             h2 Funktionsweise
             p Die technische Umsetzung für die Erstellung eines 3D-Modells aus den 2D-Fotos besteht aus verschiedenen Zwischenschritten, die ineinander greifen. Von jedem Lacksiegel der Sammlung existiert ein Foto, aus welchem wir die Siegelabdrücke automatisch freistellen und die Form herausfiltern. Neben rechteckigen und ovalen Siegelformen existieren auch weitere nicht-triviale Formen, die aufwendiger zu erkennen sind. Im nächsten Schritt berechnet unser Algorithmus Höheninformationen für das spätere 3D-Objekt unter Nutzung des Verfahrens "Shape-from-Shading (SfS)". Die Schwierigkeit entstand hierbei vor allem durch die Beleuchtung, die zum Teil ungünstige Schatten wirft, denn unser Programm arbeitet mit nur einem Foto pro Siegel. Das fertige Höhenbild wurde dann mit Bildalgorithmen nachbearbeitet, um das Rauschen zu entfernen bevor es in ein 3D-Modell umgewandelt wird.
         .container__col-sm-12
-          img#line(src="../assets/hr2.svg" width="2563" height="302")
+          img#line(src="../assets/hr2.svg" width="2563" height="302" loading="lazy" decoding="async")
         .container__col-sm-12
           #contact
             a.envelope(href="mailto:siegler.von.catan@gmail.com")

--- a/app/pages/Home.vue
+++ b/app/pages/Home.vue
@@ -41,7 +41,7 @@
               source(media="(max-width: 843px)" srcset="../assets/fabricatedSeal_562w.jpg")
               source(media="(min-width: 844px)" srcset="../assets/fabricatedSeal_1124w.webp")
               source(media="(min-width: 844px)" srcset="../assets/fabricatedSeal_1124w.jpg")
-              img(src="../assets/fabricatedSeal_1124w.jpg" alt="Selbstgemachter Siegelstempel")
+              img(src="../assets/fabricatedSeal_1124w.jpg" alt="Selbstgemachter Siegelstempel" width="1124" height="750")
         .info-section
           .picture
             picture
@@ -51,7 +51,7 @@
               source(media="(max-width: 768px)" srcset="../assets/resindruckerErgebnis_512w.jpg")
               source(media="(min-width: 769px)" srcset="../assets/resindruckerErgebnis_1024w.webp")
               source(media="(min-width: 769px)" srcset="../assets/resindruckerErgebnis_1024w.jpg")
-              img(src="../assets/resindruckerErgebnis_1024w.jpg" alt="Resindrucker")
+              img(src="../assets/resindruckerErgebnis_1024w.jpg" alt="Resindrucker" width="1024" height="768")
           .text
             h2 How to Fabricate
             p Wie funktioniert nun die Herstellung des Siegels genau? Womit lässt sich ein Siegelstempel herstellen? Beim Durchstöbern der Siegel kann eines ausgewählt werden, welches dann als 3D-Modell angezeigt wird. Dort lässt sich sowohl eine 3D-Vorlage für die und im #[router-link(to="/guide") Herstellung mit dem 3D-Drucker] als auch eine Vektordatei für die Herstellung mit dem Lasercutter runterladen. Die besten Druckergebnisse erzielt ein Resindrucker mittels Kunstharz. Frag am besten im FabLab oder Makerspace in deiner Nähe nach, ob dort ein solcher Drucker vorhanden ist. Alternativ kannst du auch einen herkömmlichen 3D-Drucker zu Hause nutzen, der bspw mit PLA-Filament arbeitet. Hier könnten die Ergebnisse verbessert werden, indem das 3D-Modell ein leicht tieferes Relief erhält. Die Vorlage für den Lasercutter kannst du auch nutzen, um einen Siegelstempel aus Moosgummi mit einem Hobbyplotter herzustellen.
@@ -67,7 +67,7 @@
               source(media="(max-width: 856px)" srcset="../assets/siegelsammlung_grun_571w.jpg")
               source(media="(min-width: 857px)" srcset="../assets/siegelsammlung_grun_1142w.webp")
               source(media="(min-width: 857px)" srcset="../assets/siegelsammlung_grun_1142w.jpg")
-              img(src="../assets/siegelsammlung_grun_1142w.jpg" alt="Siegelsammlung Grun")
+              img(src="../assets/siegelsammlung_grun_1142w.jpg" alt="Siegelsammlung Grun" width="1142" height="922")
         .info-section
           .picture
             picture
@@ -77,7 +77,7 @@
               source(media="(max-width: 960px)" srcset="../assets/pipeline_640w.gif")
               source(media="(min-width: 961px)" srcset="../assets/pipeline_1280w.webp")
               source(media="(min-width: 961px)" srcset="../assets/pipeline_1280w.gif")
-              img(src="../assets/pipeline_1280w.gif" alt="Pipeline")
+              img(src="../assets/pipeline_1280w.gif" alt="Pipeline" width="1280" height="696")
           .text
             h2 Funktionsweise
             p Die technische Umsetzung für die Erstellung eines 3D-Modells aus den 2D-Fotos besteht aus verschiedenen Zwischenschritten, die ineinander greifen. Von jedem Lacksiegel der Sammlung existiert ein Foto, aus welchem wir die Siegelabdrücke automatisch freistellen und die Form herausfiltern. Neben rechteckigen und ovalen Siegelformen existieren auch weitere nicht-triviale Formen, die aufwendiger zu erkennen sind. Im nächsten Schritt berechnet unser Algorithmus Höheninformationen für das spätere 3D-Objekt unter Nutzung des Verfahrens "Shape-from-Shading (SfS)". Die Schwierigkeit entstand hierbei vor allem durch die Beleuchtung, die zum Teil ungünstige Schatten wirft, denn unser Programm arbeitet mit nur einem Foto pro Siegel. Das fertige Höhenbild wurde dann mit Bildalgorithmen nachbearbeitet, um das Rauschen zu entfernen bevor es in ein 3D-Modell umgewandelt wird.

--- a/app/pages/Home.vue
+++ b/app/pages/Home.vue
@@ -82,7 +82,7 @@
             h2 Funktionsweise
             p Die technische Umsetzung für die Erstellung eines 3D-Modells aus den 2D-Fotos besteht aus verschiedenen Zwischenschritten, die ineinander greifen. Von jedem Lacksiegel der Sammlung existiert ein Foto, aus welchem wir die Siegelabdrücke automatisch freistellen und die Form herausfiltern. Neben rechteckigen und ovalen Siegelformen existieren auch weitere nicht-triviale Formen, die aufwendiger zu erkennen sind. Im nächsten Schritt berechnet unser Algorithmus Höheninformationen für das spätere 3D-Objekt unter Nutzung des Verfahrens "Shape-from-Shading (SfS)". Die Schwierigkeit entstand hierbei vor allem durch die Beleuchtung, die zum Teil ungünstige Schatten wirft, denn unser Programm arbeitet mit nur einem Foto pro Siegel. Das fertige Höhenbild wurde dann mit Bildalgorithmen nachbearbeitet, um das Rauschen zu entfernen bevor es in ein 3D-Modell umgewandelt wird.
         .container__col-sm-12
-          img#line(src="../assets/hr2.svg")
+          img#line(src="../assets/hr2.svg" width="2563" height="302")
         .container__col-sm-12
           #contact
             a.envelope(href="mailto:siegler.von.catan@gmail.com")

--- a/app/pages/Page.vue
+++ b/app/pages/Page.vue
@@ -20,7 +20,7 @@
   #app
     header
       router-link.logo(to="/")
-        img(src="../assets/FabSealLogo_464w.png" alt="FabSeal Logo")
+        img(src="../assets/FabSealLogo_464w.png" alt="FabSeal Logo" width="464" height="476")
       menu
         router-link(to="/home") Home
         router-link(to="/browse") Browse

--- a/app/style/guide.sass
+++ b/app/style/guide.sass
@@ -54,6 +54,7 @@
 
     img
       width: 100%
+      height: auto
 
   .text
     display: block

--- a/app/style/home.sass
+++ b/app/style/home.sass
@@ -109,6 +109,7 @@
 
     img
       width: 100%
+      height: auto
 
   .text
     display: block

--- a/app/style/page.sass
+++ b/app/style/page.sass
@@ -73,6 +73,7 @@ header
   .logo img
     display: inline
     height: 2em
+    width: auto
 
   menu
     margin: .6em 0 .8em

--- a/app/util/api.ts
+++ b/app/util/api.ts
@@ -20,6 +20,8 @@
 import axios from "axios";
 
 const domain = process.env.DOMAIN || "";
+const apiEndpoint = domain + "/api";
+const staticEndpoint = domain + "/staticBrowse";
 
 export interface Siegel {
     id: number;
@@ -28,17 +30,17 @@ export interface Siegel {
 }
 
 export async function getRandomData(amount: number) {
-    const result = await axios.get(domain + "/randomSiegels", {params: {amount}});
+    const result = await axios.get(apiEndpoint + "/randomSiegels", {params: {amount}});
     return result.data.siegel as Siegel[];
 }
 
 export async function getDataFor(i: string) {
-    const result = await axios.get(domain + "/data", {params: {i}});
+    const result = await axios.get(apiEndpoint + "/data", {params: {i}});
     return result.data.siegel as Siegel;
 }
 
 export function getFileUrl(type: string, siegel: Siegel) {
-    return `${domain}/siegeldata?type=${type}&id=${siegel.id}`;
+    return `${apiEndpoint}/siegeldata?type=${type}&id=${siegel.id}`;
 }
 
 export function openDetails(s: Siegel) {
@@ -46,14 +48,14 @@ export function openDetails(s: Siegel) {
 }
 
 export function getSealBrowseCoordinatesUrl() {
-  return domain + "/staticBrowse/browseSealCoordinates.csv";
+  return staticEndpoint + "/browseSealCoordinates.csv";
 }
 
 export function getThumbnailUrl(id: Number, size: Number) {
-  return domain + `/staticBrowse/thumbnails/thumb-${size}/seal-record_kuniweb_${id}-img.png`;
+  return staticEndpoint + `/thumbnails/thumb-${size}/seal-record_kuniweb_${id}-img.png`;
 }
 
 export async function getIdForRecordId(id: Number) {
-  const result = await axios.get(domain + `/id?recordid=${id}`);
+  const result = await axios.get(apiEndpoint + `/id?recordid=${id}`);
   return result.data;
 }


### PR DESCRIPTION
- Move backend requests to URLs below `/api`
- Specify image aspect ratio to prevent layout shifts
- Use lazy loading for images